### PR TITLE
fix: sort vec fields

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,8 +145,10 @@ fn parse_yaml(doc: Yaml, eid_subcategory_pair: &Vec<(String, String)>) -> Option
                 }
             }
         }
-        let event_ids: Vec<String> = event_ids.into_iter().collect();
-        let subcategories: Vec<String> = subcategories.into_iter().collect();
+        let mut event_ids: Vec<String> = event_ids.into_iter().collect();
+        event_ids.sort();
+        let mut subcategories: Vec<String> = subcategories.into_iter().collect();
+        subcategories.sort();
         return Some(json!({
             "id": uuid,
             "title": title,


### PR DESCRIPTION
Even when there were no updates to the Sigma rule, unnecessary PRs were being generated, 
https://github.com/Yamato-Security/WELA/pulls?q=is%3Apr+is%3Aclosed
so I modified the code to sort by eid and subcategory_uuid to prevent unwanted diffs.

I’d appreciate it if you could check it when you have time🙏